### PR TITLE
fix wrong deploy step in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run:
+          command: yarn build
+      - run:
           name: deploy
           command: yarn deploy
 workflows:


### PR DESCRIPTION
## Implements
run `yarn build` when execute deploy job